### PR TITLE
Add Safeguard to Open Source tools

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -217,6 +217,7 @@ If you find this list helpful, give it a ⭐ on GitHub, share it, and contribute
 | [NeMo-Guardrails](https://github.com/NVIDIA/NeMo-Guardrails) | `all` | NeMo Guardrails is an open-source toolkit for easily adding programmable guardrails to LLM-based conversational systems. |
 | [uqlm](https://github.com/cvs-health/uqlm) | `hallucination` | UQLM: Uncertainty Quantification for Language Models, is a Python package for UQ-based LLM hallucination detection. |
 | [llm-guard](https://github.com/protectai/llm-guard) | `all` | The Security Toolkit for LLM Interactions. |
+| [Safeguard](https://github.com/lukeslp/oss-safeguard-ux) | `inappropriate-content` | Web interface for OpenAI's gpt-oss-safeguard model with streaming verdicts, policy customization, and WCAG 2.1 AA accessibility. |
 
 ### Closed Source
 


### PR DESCRIPTION
## Summary

- Adds [Safeguard](https://github.com/lukeslp/oss-safeguard-ux) to the Open Source section
- Safeguard is a web interface for OpenAI's gpt-oss-safeguard content safety classifier
- Features: streaming verdicts via SSE, editable policy definitions, WCAG 2.1 AA accessibility, zero dependencies

Fits the `inappropriate-content` category as it provides a front-end for content safety classification.