### PR TITLE
Add APort guardrail provider

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -222,6 +222,7 @@ If you find this list helpful, give it a ⭐ on GitHub, share it, and contribute
 
 | Name | Category | Description |
 |------|----------|-------------|
+| [APort](https://aport.io) | `security-and-privacy` | APort provides agent identity verification and policy enforcement for AI agents through SDKs and middleware. |
 | [Lakera](https://www.lakera.ai/lakera-guard) | `all` | Lakera is a company that provides a range of AI services. |
 | [Guardrails AI Pro](https://www.guardrailsai.com/pro) | `all` | Guardrails AI Pro is a commercial version of guardrails that provides additional features and support. |
 

--- a/scripts/readme_template.md
+++ b/scripts/readme_template.md
@@ -35,6 +35,7 @@ If you find this list helpful, give it a ⭐ on GitHub, share it, and contribute
 
 | Name | Category | Description |
 |------|----------|-------------|
+| [APort](https://aport.io) | `security-and-privacy` | APort provides agent identity verification and policy enforcement for AI agents through SDKs and middleware. |
 | [Lakera](https://www.lakera.ai/lakera-guard) | `all` | Lakera is a company that provides a range of AI services. |
 | [Guardrails AI Pro](https://www.guardrailsai.com/pro) | `all` | Guardrails AI Pro is a commercial version of guardrails that provides additional features and support. |
 


### PR DESCRIPTION
## Summary
- Add APort to the Closed Source guardrail providers table.
- Update both `readme.md` and `scripts/readme_template.md` so the generated README keeps the entry.

## Why this fits
APort provides agent identity verification and policy enforcement for AI agents, which is aligned with the `security-and-privacy` guardrails category.

## Verification
- `$env:PYTHONUTF8="1"; python scripts/create_readme.py`
- `git diff --check -- readme.md scripts/readme_template.md`
- `rg -n "APort|aport.io" readme.md scripts/readme_template.md`
- `curl.exe -I -L --max-time 20 https://aport.io`

Related bounty: https://github.com/aporthq/aport-integrations/issues/19

Payout if selected for the bounty: PayPal https://paypal.me/Jeremytsangchina or USDT TRC20 TWupTAoFjxR2VmqUUvzhfmUwXVZR6Kvz1Y