### PR TITLE
Add Armorer Guard

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -213,6 +213,7 @@ If you find this list helpful, give it a ⭐ on GitHub, share it, and contribute
 
 | Name | Category | Description |
 |------|----------|-------------|
+| [Armorer Guard](https://github.com/ArmorerLabs/Armorer-Guard) | `security-and-privacy` | Local Rust scanner and MCP proxy for AI-agent prompt injection, credential leakage, exfiltration, and risky tool-call arguments. |
 | [guardrails](https://github.com/guardrails-ai/guardrails) | `all` | Adding guardrails to large language models. |
 | [NeMo-Guardrails](https://github.com/NVIDIA/NeMo-Guardrails) | `all` | NeMo Guardrails is an open-source toolkit for easily adding programmable guardrails to LLM-based conversational systems. |
 | [uqlm](https://github.com/cvs-health/uqlm) | `hallucination` | UQLM: Uncertainty Quantification for Language Models, is a Python package for UQ-based LLM hallucination detection. |


### PR DESCRIPTION
Adds Armorer Guard to the open-source guardrails table.\n\nDisclosure: I maintain Armorer Guard at Armorer Labs. It is a MIT-licensed local Rust scanner and MCP proxy for AI-agent prompt injection, credential leakage, exfiltration, and risky tool-call arguments. It fits the security-and-privacy guardrail category because it is designed to sit in the runtime path for agent prompts, outputs, and MCP tool calls.\n\nThanks for maintaining this guardrails list.